### PR TITLE
fix ambiguous file format in validation config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,11 +7,11 @@ consul_user_uid: 3000
 consul_user_home: /opt/consul
 consul_config_dir: "{{ consul_user_home }}/conf.d"
 consul_data_dir: "{{ consul_user_home }}/data"
-consul_version: 1.0.1
+consul_version: 1.0.7
 consul_server: false
 consul_uri: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_linux_amd64.zip"
 consul_config_src: main.json.j2
-consul_config_validate: "{{ consul_user_home }}/bin/consul validate %s"
+consul_config_validate: "{{ consul_user_home }}/bin/consul validate -config-format=json %s"
 consul_extra_args: []
 consul_service_file:
   src: consul.service.j2

--- a/templates/consul.service.j2
+++ b/templates/consul.service.j2
@@ -14,7 +14,7 @@ ExecStartPre=/usr/bin/install -d /run/consul -o {{ consul_user_name }} -g {{ con
 ExecStartPre=/usr/bin/touch /run/consul/consul.pid
 ExecStartPre=/bin/chown {{ consul_user_name }}:{{ consul_group_name }} /run/consul/consul.pid 
 ExecStart={{ consul_user_home }}/bin/consul agent {% if consul_extra_args > 0 %}{% for arg in consul_extra_args %}{{arg}} {% endfor %}{% endif %}-pid-file=/run/consul/consul.pid -config-dir={{ consul_config_dir }}
-ExecStopPost=[ -f "/run/consul/consul.pid" ] && /usr/bin/rm -f /run/consul/consul.pid
+ExecStopPost=/usr/bin/[ -f "/run/consul/consul.pid" /usr/bin/] && /usr/bin/rm -f /run/consul/consul.pid
 ExecReload=/bin/kill -s HUP $MAINPID
 KillSignal=SIGINT
 TimeoutStopSec=5


### PR DESCRIPTION
Hi there!
nice work with the project. Unfortunately i have encountered the error `Config validation failed: data_dir cannot be empty` because Ansibile in the validation phase use the file with extension .j2 and consul don't parse this by default.
Option `-config-format=json` is available to consul from 1.0.7 so also consul need update.
There are many way to workaround/fix this, but hope my proposed solution is correct enough.
Bye
Jacopo